### PR TITLE
Add a nested menu to list all MDX pages

### DIFF
--- a/theme/src/components/menus/allPagesMenu.tsx
+++ b/theme/src/components/menus/allPagesMenu.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import SideNav from './SideNav'
+
+interface AllPagesMenuProps {
+  nodes: Node[];
+  heading?: string;
+  headingType?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
+  showHeading?: boolean;
+}
+
+const AllPagesMenu: React.FC<AllPagesMenuProps> = ({
+  nodes,
+  heading = 'All pages',
+  headingType = 'h2',
+  showHeading = false,
+}) => {
+  // Function to group entries based on slug levels and convert to new object structure
+  const convertToStructure = (entries) => {
+    return Object.keys(entries).map((key) => {
+      const entry = entries[key];
+      const newItem = {
+        title: entry.title || key,
+        url: entry.url || '',
+        items: []
+      };
+      if (entry.items) {
+        newItem.items = convertToStructure(entry.items);
+      }
+      return newItem;
+    });
+  };
+
+  // Function to group entries based on slug levels
+  const groupItemsBySlugLevels = (entries) => {
+    const groupedItems = {};
+
+    entries.forEach((entry) => {
+      const slugLevels = entry.fields.slug.split('/').filter((level) => level !== '');
+      let currentGroup = groupedItems;
+
+      slugLevels.forEach((level, index) => {
+        if (!currentGroup[level]) {
+          currentGroup[level] = {};
+        }
+        if (index === slugLevels.length - 1) {
+          currentGroup[level].url = entry.fields.slug || "";
+          currentGroup[level].title = entry.frontmatter.title;
+        } else {
+          if (!currentGroup[level].items) {
+            currentGroup[level].items = {};
+          }
+          currentGroup = currentGroup[level].items;
+        }
+      });
+    });
+
+    return convertToStructure(groupedItems);
+  };
+
+  const groupedItems = groupItemsBySlugLevels(nodes);
+  let groupedItemsObject = {}
+  groupedItemsObject['items'] = groupedItems
+
+  return (
+    <nav>
+      <SideNav heading={heading} headingType={headingType} content={groupedItemsObject} showHeading={showHeading} />
+    </nav>
+  );
+};
+
+export default AllPagesMenu;

--- a/theme/src/templates/PageTemplate.tsx
+++ b/theme/src/templates/PageTemplate.tsx
@@ -9,11 +9,12 @@ import Banner from '../components/Banner'
 import ImgCard from '../components/ImgCard'
 import MDXRender from '../components/MDXRender'
 import SideNav from '../components/menus/SideNav'
+import AllPagesMenu from '../components/menus/AllPagesMenu'
 
 import defaultImage from '../images/card-image.jpg'
 import { ParamsContext } from '../paramsContext'
 
-const PageTemplate = ({ data: { site, mdx: page, allMdx: childPages }, children, location }) => {
+const PageTemplate = ({ data: { site, mdx: page, bottomMenu: childPages, sideMenu }, children, location }) => {
   // If the page has a query of ?render=noFrame, then just return the content
   const urlParams = new URLSearchParams(location.search)
   const noFrame = urlParams.get('render') === 'noFrame' || false
@@ -74,9 +75,12 @@ const PageTemplate = ({ data: { site, mdx: page, allMdx: childPages }, children,
                   <Grid item xs={12} md={hasSidebar ? 8 : 12}>
                     <MDXRender>{children}</MDXRender>
                   </Grid>
+                  
+  
                   {hasSidebar && (
                     <Grid item xs={12} md={4} component="aside">
                       <SideNav heading="On this page" headingType="h2" content={page.tableOfContents} showHeading />
+                      <AllPagesMenu heading="All pages" headingType="h2" nodes={sideMenu.nodes} showHeading />
                     </Grid>
                   )}
                 </Grid>
@@ -123,7 +127,7 @@ export const pageQuery = graphql`
       tableOfContents(maxDepth: 3)
     }
     # TODO: NOTICE THE HARD CODING TO REGEX MATCH THE SLUG
-    allMdx(filter: { fields: { slug: { regex: "/our-work//" } } }) {
+    bottomMenu: allMdx(filter: { fields: { slug: { regex: "/our-work//" } } }) {
       nodes {
         id
         fields {
@@ -140,6 +144,16 @@ export const pageQuery = graphql`
               gatsbyImageData(width: 800)
             }
           }
+        }
+      }
+    }
+    sideMenu: allMdx {
+      nodes {
+        frontmatter {
+          title
+        }
+        fields {
+          slug
         }
       }
     }


### PR DESCRIPTION

@MattReimer Based on our discussions, I am pulling in all pages MDX files as defined in `gatsby-config.js` and using their information for the side menu. Please test and verify if the setup is as intended.

----

### Summary
This pull request introduces a new `AllPagesMenu` component, which dynamically generates a nested navigation menu based on a provided list of MDX nodes. The component processes the page nodes, which include titles and slugs from the MDX frontmatter, to group them by slug levels and output a structured navigation menu.

### Changes
- **New Component**: `AllPagesMenu`
  - Takes `nodes`, `heading`, `headingType`, and `showHeading` as props.
  - Default `heading` is "All pages".
  - Default `headingType` is 'h2'.
  - Default `showHeading` is `false`.
- **Utility Functions**:
  - `convertToStructure(entries)`: Recursively transforms grouped entries into a new object structure suitable for the `SideNav` component.
  - `groupItemsBySlugLevels(entries)`: Groups page entries by their slug levels, facilitating the creation of nested menu items.
- **Integration**:
  - The `groupedItemsObject` is passed to the `SideNav` component as `content`.

### Implementation Details
1. **Grouping Logic**:
   - `groupItemsBySlugLevels(entries)`: Iterates through the page nodes to group them by their slug levels.
   - Constructs a nested object where each level corresponds to a part of the slug path.
   - Each entry at the final slug level includes the `url` and `title`.
2. **Conversion to Menu Structure**:
   - `convertToStructure(entries)`: Converts the grouped object into an array format suitable for rendering by the `SideNav` component.
   - Ensures that each item contains `title`, `url`, and `items` properties.
3. **Rendering**:
   - The `AllPagesMenu` component renders a `nav` element containing the `SideNav` component.
   - Passes the structured navigation data and heading configuration to `SideNav`.