### PR TITLE
Allow using 8gb for node process when developing gatsby site

### DIFF
--- a/sites/devsite/package.json
+++ b/sites/devsite/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "gatsby build",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "start": "gatsby develop -p 8002",
+    "start": "NODE_OPTIONS='--max-old-space-size=8192' && gatsby develop -p 8002",
     "start:clean": "yarn clean; gatsby develop -p 8002",
     "optimize": "node scripts/optimizeImages.js",
     "serve": "gatsby serve -p 8002 -H 0.0.0.0",


### PR DESCRIPTION
Developers won't have to worry about figuring this out themselves in the future